### PR TITLE
fix encoding issue in case of languages other than English

### DIFF
--- a/src/Reader.php
+++ b/src/Reader.php
@@ -40,6 +40,10 @@ class Reader
 
         // read file 
         $this->file = file_get_contents($file);
+		
+		// Fix encoding issue when non ascii charcters are there.
+		$this->file = mb_convert_encoding($this->file, 'UTF-8',
+          mb_detect_encoding($this->file, 'UTF-8, ISO-8859-1', true));
     }
 
     /**


### PR DESCRIPTION
I recently faced an issue when bml fine contained characters like ǖ ǘ ǚ ǜ.
To fix this we need to some content encoding.